### PR TITLE
Fix startup crash if the specified socket already exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,16 @@
 import { env } from "process";
 import { app, logger } from "./app";
 import http from "http";
+import { existsSync, rmSync } from "fs";
 
 const server = http.createServer(app);
 
 if (process.env.SOCKET_PATH != null && process.env.SOCKET_PATH.length > 0) {
+  // Remove the socket at the specified path if it already exists to avoid EADDRINUSE
+  if (existsSync(process.env.SOCKET_PATH)) {
+    rmSync(process.env.SOCKET_PATH);
+  }
+
   server.listen({
     path: process.env.SOCKET_PATH,
     readableAll: true,


### PR DESCRIPTION
Small fix since we encountered this issue today.